### PR TITLE
fix: In servers_specs.yml, use block style rather than mixed style

### DIFF
--- a/servers_specs.yml
+++ b/servers_specs.yml
@@ -1,6 +1,22 @@
 ---
 servers:
-  - { name: 'outstanding_oatmeal', image: 'Rocky Linux 9 x86_64', default_user: 'cloud-user', flavor: 'b.1c1gb', vol_size: '10' }
-  - { name: 'prestigious_pancake', image: 'Rocky Linux 9 x86_64', default_user: 'cloud-user', flavor: 'b.1c2gb', vol_size: '12' }
-  - { name: 'quarrelsome_quarter', image: 'Debian 11 Bullseye x86_64', default_user: 'debian', flavor: 'b.1c1gb', vol_size: '10' }
-  - { name: 'responsible_ravioli', image: 'Ubuntu 22.04 Jammy Jellyfish x86_64', default_user: 'ubuntu', flavor: 'b.2c2gb', vol_size: '10' }
+  - name: 'outstanding_oatmeal'
+    image: 'Rocky Linux 9 x86_64'
+    default_user: 'cloud-user'
+    flavor: 'b.1c1gb'
+    vol_size: 10
+  - name: 'prestigious_pancake'
+    image: 'Rocky Linux 9 x86_64'
+    default_user: 'cloud-user'
+    flavor: 'b.1c2gb'
+    vol_size: 12
+  - name: 'quarrelsome_quarter'
+    image: 'Debian 11 Bullseye x86_64'
+    default_user: 'debian'
+    flavor: 'b.1c1gb'
+    vol_size: 10
+  - name: 'responsible_ravioli'
+    image: 'Ubuntu 22.04 Jammy Jellyfish x86_64'
+    default_user: 'ubuntu'
+    flavor: 'b.2c2gb'
+    vol_size: 10


### PR DESCRIPTION
Without this change, `servers_specs.yml` uses an odd combination of block and flow style, resulting in very long lines that might wrap around in the lab terminal.

It's much cleaner to use block style here, so do just that.

Also, `vol_size` is meant to be a numeric value, so drop the quotes around it.