### PR TITLE
feat: Auto-discover ansible_user

### DIFF
--- a/group_vars/debian
+++ b/group_vars/debian
@@ -1,2 +1,3 @@
+# You can set any variables here that apply just to the hosts running
+# Debian GNU/Linux.
 ---
-ansible_user: debian

--- a/group_vars/rocky
+++ b/group_vars/rocky
@@ -1,2 +1,3 @@
+# You can set any variables here that apply just to the hosts running
+# Rocky Linux.
 ---
-ansible_user: cloud-user

--- a/group_vars/ubuntu
+++ b/group_vars/ubuntu
@@ -1,2 +1,3 @@
+# You can set any variables here that apply just to the hosts running
+# Ubuntu.
 ---
-ansible_user: ubuntu

--- a/openstack.yml
+++ b/openstack.yml
@@ -5,6 +5,7 @@ only_clouds: []
 legacy_groups: false
 compose:
   'os_distro': 'openstack.volumes[0].volume_image_metadata.os_distro'
+  'ansible_user': 'openstack.volumes[0].volume_image_metadata.image_original_user'
 keyed_groups:
   - prefix: ''
     key: 'os_distro'


### PR DESCRIPTION
Now that our base images support the `image_original_user` property as defined by the SCS Image Metadata Standard, we can use the `compose` key in the OpenStack inventory configuration dictionary to set the `ansible_user` variable directly, removing the need for deducing it from `os_distro`.

Thus:

* Drop `ansible_user` from the distro-specific `group_vars` files.
* Set `ansible_user` from the dynamic inventory plugin.