### PR TITLE
fix: Drop vars_files reference from teardown playbook

### DIFF
--- a/teardown.yml
+++ b/teardown.yml
@@ -3,9 +3,6 @@
   connection: local
   gather_facts: false
 
-  vars_files:
-    - servers_specs.yml
-
   tasks:
     - name: Delete servers
       openstack.cloud.server:


### PR DESCRIPTION
We no longer use that file; we instead pull in the same data from `host_vars/localhost`.