### PR TITLE
feat: Add requirements.yml

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+- name: "openstack.cloud"
+  version: ">=2.2.0"
+- name: "community.general"
+- name: "community.crypto"


### PR DESCRIPTION
Since the `openstack.cloud` collection is broken from version 1.5.1 forward (it does not provide idempotency for routers when used with dual-stack external networks), fix the tutorial so that it requires at least version 2.2.0 of that collection.