### PR TITLE
Update template to enable config_drive for server instances

### DIFF
--- a/servers.yml
+++ b/servers.yml
@@ -17,5 +17,6 @@
         network: ansible_net
         auto_ip: true
         security_groups: ansible_sg
+        config_drive: true
         wait: true
       with_items: '{{ servers }}'


### PR DESCRIPTION
Update template to use config_drive instead of metadata service for instance configuration