### PR TITLE
Refresh Ansible workbench

### DIFF
--- a/host_vars/localhost
+++ b/host_vars/localhost
@@ -13,6 +13,6 @@ servers:
     flavor: 'b.1c1gb'
     vol_size: 10
   - name: 'responsible_ravioli'
-    image: 'Ubuntu 22.04 Jammy Jellyfish x86_64'
+    image: 'Ubuntu 24.04 Noble Numbat x86_64'
     flavor: 'b.2c2gb'
     vol_size: 10

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
 - name: "openstack.cloud"
-  version: ">=2.4.1"
 - name: "community.general"
 - name: "community.crypto"


### PR DESCRIPTION
- We make sure all Ansible playbooks reference the newer Ubuntu Noble Numbat instead of the old Jammy Jellyfish image.

- Regarding the installation of the openstack.cloud collection, we no longer use version pinning.